### PR TITLE
Added quotations around file args of 'execString'

### DIFF
--- a/lib/sass-autocompile-view.coffee
+++ b/lib/sass-autocompile-view.coffee
@@ -149,7 +149,7 @@ class SassAutocompileView extends View
 
             @startCompiling params.file
             try
-                execString = 'node-sass --output-style ' + outputStyle + ' ' + params.file + ' ' + cssFilename
+                execString = 'node-sass --output-style ' + outputStyle + ' "' + params.file + '" "' + cssFilename + '"'
                 exec execString, (error, stdout, stderr) =>
                     if error != null
                         if error.message.indexOf('"message"') > -1


### PR DESCRIPTION
Without quotes around the file arguments of 'execString', users with spaces in their file paths (or their username itself, like in my case) received a "File does not exist" error upon attempting to compile SCSS code. This commit fixes the issue.
(As a side note, thank you for making this wonderful atom package!)