### PR TITLE
Fixed-path de-filtering. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 **0.9.1 - 17.09.2015**
 - Modified option: Killed darwin-only to allow any OS (eg Ubuntu – which has process.platform "linux") to enjoy the "Path to 'node-sass'" option.
-- 
+
 **0.9.0 - 31.08.2015**
 - New option: Indent type / as inline parameter: indentType
 - New option: Indent width / as inline parameter: indentWidth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**0.9.1 - 17.09.2015**
+- Modified option: Killed darwin-only to allow any OS (eg Ubuntu – which has process.platform "linux") to enjoy the "Path to 'node-sass'" option.
+- 
 **0.9.0 - 31.08.2015**
 - New option: Indent type / as inline parameter: indentType
 - New option: Indent width / as inline parameter: indentWidth
@@ -16,7 +19,7 @@
 - Fixed includePath parameter option, so it works correctly now
 
 **0.7.4 - 30.07.2015**
-- Added support for `.sass` file extension (thanks to [Chris Kj�rsig](https://github.com/cmk2179) for this idea!)
+- Added support for `.sass` file extension (thanks to [Chris Kjærsig](https://github.com/cmk2179) for this idea!)
 
 **0.7.3 - 24.07.2015**
 - Bugfix: Fixed issue [#10](https://github.com/armin-pfaeffle/sass-autocompile/issues/10)

--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ If enabled detailed output of node-sass command is automatically shown in a new 
 *__Default__: false*
 
 
-#### ONLY FOR MAC OS: Path to 'node-sass' command
-This option is ONLY FOR MAC OS! If *sass-autocompile* can not find `node-sass` command you can set this path to where `node-sass` command is placed, so the absolute path can be used. Only use this option when Atom throws the error "command not found".  
+#### Path to 'node-sass' command
+This option is especially for Mac OS and Linux systems like Ubuntu. If *sass-autocompile* can not find `node-sass` command you can set this path to where `node-sass` command is placed, so the absolute path can be used. Only use this option when Atom throws the error "command not found".  
 *__Default__: '/usr/local/bin'*
 
 

--- a/lib/sass-autocompile-view.coffee
+++ b/lib/sass-autocompile-view.coffee
@@ -225,10 +225,13 @@ class SassAutocompileView extends View
 
         # If it's Mac OS we have to add macOsNodeSassPath to command and to environment variable
         # PATH so shell AND node.js can find node-sass command
-        if process.platform is "darwin"
-            path = require('path')
-            command = path.join(@options.macOsNodeSassPath, command)
-            environment.PATH += ":#{@options.macOsNodeSassPath}"
+        
+        # Change: let user decide for himself if user wants to set a fixed part. 
+        # Reason: process.platform "linux" (eg Ubuntu) tends to need this fix too.
+        # if process.platform is "darwin"
+        path = require('path')
+        command = path.join(@options.macOsNodeSassPath, command)
+        environment.PATH += ":#{@options.macOsNodeSassPath}"
 
         return {
             command: command,

--- a/lib/sass-autocompile.coffee
+++ b/lib/sass-autocompile.coffee
@@ -156,7 +156,7 @@ module.exports =
             order: 65
 
         macOsNodeSassPath:
-            title: 'ONLY FOR MAC OS: Path to \'node-sass\' command'
+            title: 'Path to \'node-sass\' command (might fix \'node-sass not found\' issues)'
             description: 'Absolute path where \'node-sass\' command can be found'
             type: 'string'
             default: '/usr/local/bin'

--- a/lib/sass-autocompile.coffee
+++ b/lib/sass-autocompile.coffee
@@ -156,7 +156,7 @@ module.exports =
             order: 65
 
         macOsNodeSassPath:
-            title: 'Path to \'node-sass\' command (might fix \'node-sass not found\' issues)'
+            title: 'Absolute path where \'node-sass\' resides (might fix \'node-sass not found\' issues)'
             description: 'Absolute path where \'node-sass\' command can be found'
             type: 'string'
             default: '/usr/local/bin'


### PR DESCRIPTION
Killed darwin-only to allow any OS (eg Ubuntu – which has process.platform "linux") to enjoy the fixed path option in the settings page. Additionally reworded the text of the according settings page to make things fit.